### PR TITLE
Catch IOException parsing manifest

### DIFF
--- a/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
+++ b/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java
@@ -742,7 +742,7 @@ public class JarAnalyzer extends AbstractFileTypeAnalyzer {
                 versionEvidence.addEvidence(source, "specification-version", specificationVersion, Confidence.HIGH);
             }
         } catch (IOException ex) {
-            LOGGER.warn("Unable to read JarFile '{}'.", dependency.getActualFilePath());
+            LOGGER.warn("Unable to read dependency file '{}'", dependency.getActualFilePath());
             LOGGER.trace("", ex);
         }
         return foundSomething;

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
@@ -17,23 +17,21 @@
  */
 package org.owasp.dependencycheck.analyzer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 
 import org.junit.Test;
 import org.owasp.dependencycheck.BaseTest;
+import org.owasp.dependencycheck.analyzer.JarAnalyzer.ClassNameInformation;
 import org.owasp.dependencycheck.dependency.Dependency;
 import org.owasp.dependencycheck.dependency.Evidence;
 import org.owasp.dependencycheck.utils.Settings;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Jeremy Long
@@ -175,5 +173,12 @@ public class JarAnalyzerTest extends BaseTest {
         List<String> expected = Arrays.asList("owasp", "dependencycheck", "analyzer", "jaranalyzer");
         List<String> results = instance.getPackageStructure();
         assertEquals(expected, results);
+    }
+
+    @Test
+    public void testParseManifest_CatchesIOException() {
+        Dependency dependency = new Dependency();
+        dependency.setActualFilePath("doesNotExist");
+        assertFalse(new JarAnalyzer().parseManifest(dependency, new ArrayList<ClassNameInformation>()));
     }
 }

--- a/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
+++ b/dependency-check-core/src/test/java/org/owasp/dependencycheck/analyzer/JarAnalyzerTest.java
@@ -179,6 +179,7 @@ public class JarAnalyzerTest extends BaseTest {
     public void testParseManifest_CatchesIOException() {
         Dependency dependency = new Dependency();
         dependency.setActualFilePath("doesNotExist");
+        assertFalse(new File(dependency.getActualFilePath()).exists());
         assertFalse(new JarAnalyzer().parseManifest(dependency, new ArrayList<ClassNameInformation>()));
     }
 }


### PR DESCRIPTION
## Description of Change

Catch and log `IOException` when parsing manifest for two reasons:

1.  To prevent an `ExceptionCollection` exception being thrown by `engine.analyzeDependencies()` when analyzing unreadable jars/zips. This is useful because these errors could be common (x) and unnecessarily bloat any `ExceptionCollection`. Also it would make it easier to determine whether to continue or not especially for external uses of `engine.analyzeDependencies()`.

(x) when compressing files on macOS it may create mirror `._` files (same filename except with the `._` prefix), these files aren't actual copies they just contain file information, but if `engine.analyzeDependencies()`  sees `._some_file.jar` it will fail to parse its manifest throwing an `IOException` because it's unreadable.

2. To be consistent with other usages of `try (JarFile jar = new JarFile(dependency.getActualFilePath()))`

https://github.com/jeremylong/DependencyCheck/blob/fb2b3159e8dedaad06cb3b6f667975616fbd848f/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java#L313
https://github.com/jeremylong/DependencyCheck/blob/fb2b3159e8dedaad06cb3b6f667975616fbd848f/dependency-check-core/src/main/java/org/owasp/dependencycheck/analyzer/JarAnalyzer.java#L914

## Have test cases been added to cover the new functionality?

*yes*